### PR TITLE
Update configuration for sample app integration

### DIFF
--- a/LDAP-Dockerized-CentOS/users.ldif
+++ b/LDAP-Dockerized-CentOS/users.ldif
@@ -14,9 +14,10 @@ uid: winstonhong
 sn: Hong
 givenName: Winston
 cn: Winston Hong
+displayName: Winston Hong
 mail: winston.hong@example.com
 userPassword: winston-passwd
-employeeType: arn:aws:iam::my-aws-id:role/shibbolethidp,arn:aws:iam::my-aws-id:saml-provider/Shibboleth-IdP
+employeeType: developer
 employeeNumber: xWr5MnS5wEO3siztf9oFuA==
 
 dn: uid=ethansmith,ou=People,dc=example,dc=com
@@ -28,7 +29,8 @@ uid: ethansmith
 sn: Smith
 givenName: Ethan
 cn: Ethan Smith
+displayName: Ethan Smith
 mail: ethan.smith@example.com
 userPassword: ethan-passwd
-employeeType: arn:aws:iam::my-aws-id:role/shibbolethidp,arn:aws:iam::my-aws-id:saml-provider/Shibboleth-IdP
+employeeType: admin
 employeeNumber: IEFis4xZPUSiJubMtq+Yvg==

--- a/shibboleth-idp-dockerized/ext-conf/conf/attribute-resolver-full.xml
+++ b/shibboleth-idp-dockerized/ext-conf/conf/attribute-resolver-full.xml
@@ -347,4 +347,26 @@
         </dc:StartTLSTrustCredential>-->
     </resolver:DataConnector>
 
+    <!-- Zusätzliche Attribute für Anwendungsintegration -->
+    <resolver:AttributeDefinition id="displayname" xsi:type="ad:Simple">
+        <resolver:InputDataConnector ref="myLDAP" attributeNames="cn displayName"/>
+        <resolver:AttributeEncoder xsi:type="enc:SAML2String"
+                      name="urn:mace:dir:attribute-def:displayName"
+                      friendlyName="displayname"/>
+    </resolver:AttributeDefinition>
+
+    <resolver:AttributeDefinition id="email" xsi:type="ad:Simple">
+        <resolver:InputDataConnector ref="myLDAP" attributeNames="mail"/>
+        <resolver:AttributeEncoder xsi:type="enc:SAML2String"
+                      name="urn:mace:dir:attribute-def:mail"
+                      friendlyName="email"/>
+    </resolver:AttributeDefinition>
+
+    <resolver:AttributeDefinition id="employeetype" xsi:type="ad:Simple">
+        <resolver:InputDataConnector ref="myLDAP" attributeNames="employeeType"/>
+        <resolver:AttributeEncoder xsi:type="enc:SAML2String"
+                      name="urn:mace:dir:attribute-def:employeeType"
+                      friendlyName="employeetype"/>
+    </resolver:AttributeDefinition>
+
 </resolver:AttributeResolver>

--- a/shibboleth-idp-dockerized/ext-conf/conf/idp.properties
+++ b/shibboleth-idp-dockerized/ext-conf/conf/idp.properties
@@ -2,10 +2,10 @@
 idp.additionalProperties= /conf/ldap.properties, /conf/saml-nameid.properties, /conf/services.properties
 
 # Set the entityID of the IdP
-idp.entityID= https://idp.example.com/idp/shibboleth
+idp.entityID= https://shib-demo.westeurope.cloudapp.azure.com/idp/shibboleth
 
 # Set the scope used in the attribute resolver for scoped attributes
-idp.scope= example.com
+idp.scope= westeurope.cloudapp.azure.com
 
 # General cookie properties (maxAge only applies to persistent cookies)
 #idp.cookie.secure = false

--- a/shibboleth-idp-dockerized/ext-conf/conf/ldap.properties
+++ b/shibboleth-idp-dockerized/ext-conf/conf/ldap.properties
@@ -51,7 +51,7 @@ idp.attribute.resolver.LDAP.bindDNCredential    = %{idp.authn.LDAP.bindDNCredent
 idp.attribute.resolver.LDAP.useStartTLS         = %{idp.authn.LDAP.useStartTLS:true}
 idp.attribute.resolver.LDAP.trustCertificates   = %{idp.authn.LDAP.trustCertificates:undefined}
 idp.attribute.resolver.LDAP.searchFilter        = (uid=$resolutionContext.principal)
-idp.attribute.resolver.LDAP.returnAttributes    = cn,homephone,mail
+idp.attribute.resolver.LDAP.returnAttributes    = cn,homephone,mail,displayName,employeeType,givenName,sn
 
 # LDAP pool configuration, used for both authn and DN resolution
 #idp.pool.LDAP.minSize                          = 3

--- a/shibboleth-idp-dockerized/ext-conf/conf/relying-party.xml
+++ b/shibboleth-idp-dockerized/ext-conf/conf/relying-party.xml
@@ -65,13 +65,13 @@
         </bean>
         -->
 
-        <bean parent="RelyingPartyByName" c:relyingPartyIds="https://sp.example.org:2443/Shibboleth.sso/Metadata">
+        <bean parent="RelyingPartyByName" c:relyingPartyIds="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/Metadata">
             <property name="profileConfigurations">
                 <list>
                     <bean parent="SAML2.SSO" p:encryptAssertions="false" p:encryptNameIDs="false" />
                 </list>
             </property>
-        </bean>	
+        </bean>
 
         <bean parent="RelyingPartyByName" c:relyingPartyIds="https://example.my.salesforce.com">
             <property name="profileConfigurations">

--- a/shibboleth-idp-dockerized/ext-conf/metadata/sp-example-org.xml
+++ b/shibboleth-idp-dockerized/ext-conf/metadata/sp-example-org.xml
@@ -2,7 +2,7 @@
 This is example metadata only. Do *NOT* supply it as is without review,
 and do *NOT* provide it in real time to your partners.
  -->
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_2bfe46fbf65e268f30b921e7abdcc9ba1f1cdcea" entityID="https://sp.example.org:2443/Shibboleth.sso/Metadata">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_2bfe46fbf65e268f30b921e7abdcc9ba1f1cdcea" entityID="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/Metadata">
 
   <md:Extensions xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport">
     <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
@@ -25,7 +25,7 @@ and do *NOT* provide it in real time to your partners.
 
   <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:1.0:protocol">
     <md:Extensions>
-      <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://sp.example.org:2443/Shibboleth.sso/Login"/>
+      <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/Login"/>
     </md:Extensions>
     <md:KeyDescriptor>
       <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -66,17 +66,17 @@ guz5Oxg=
       <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"/>
       <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
     </md:KeyDescriptor>
-    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp.example.org:2443/Shibboleth.sso/Artifact/SOAP" index="1"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp.example.org:2443/Shibboleth.sso/SLO/SOAP"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp.example.org:2443/Shibboleth.sso/SLO/Redirect"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.org:2443/Shibboleth.sso/SLO/POST"/>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp.example.org:2443/Shibboleth.sso/SLO/Artifact"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.org:2443/Shibboleth.sso/SAML2/POST" index="1"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://sp.example.org:2443/Shibboleth.sso/SAML2/POST-SimpleSign" index="2"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp.example.org:2443/Shibboleth.sso/SAML2/Artifact" index="3"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://sp.example.org:2443/Shibboleth.sso/SAML2/ECP" index="4"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://sp.example.org:2443/Shibboleth.sso/SAML/POST" index="5"/>
-    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://sp.example.org:2443/Shibboleth.sso/SAML/Artifact" index="6"/>
+    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/Artifact/SOAP" index="1"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SLO/SOAP"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SLO/Redirect"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SLO/POST"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SLO/Artifact"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SAML2/POST" index="1"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SAML2/POST-SimpleSign" index="2"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SAML2/Artifact" index="3"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SAML2/ECP" index="4"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SAML/POST" index="5"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/SAML/Artifact" index="6"/>
   </md:SPSSODescriptor>
 
 </md:EntityDescriptor>

--- a/shibboleth-sp-testapp/appfiles/secure/.htaccess
+++ b/shibboleth-sp-testapp/appfiles/secure/.htaccess
@@ -1,0 +1,7 @@
+AuthType shibboleth
+ShibRequestSetting requireSession 1
+ShibRequestSetting applicationId default
+require valid-user
+
+# Attribute für Debugging anzeigen (nur für Tests)
+ShibUseHeaders On

--- a/shibboleth-sp-testapp/appfiles/secure/attributes.php
+++ b/shibboleth-sp-testapp/appfiles/secure/attributes.php
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Shibboleth Attribute Test</title>
+</head>
+<body>
+    <h1>Shibboleth Attribute Test</h1>
+    
+    <h2>Anwendungs-relevante Attribute:</h2>
+    <table border="1">
+        <tr><th>Attribut</th><th>HTTP-Header</th><th>Wert</th></tr>
+        <tr>
+            <td>Display Name</td>
+            <td>HTTP_DISPLAYNAME</td>
+            <td><?= htmlspecialchars($_SERVER['HTTP_DISPLAYNAME'] ?? 'NICHT GESETZT') ?></td>
+        </tr>
+        <tr>
+            <td>Email</td>
+            <td>HTTP_EMAIL</td>
+            <td><?= htmlspecialchars($_SERVER['HTTP_EMAIL'] ?? 'NICHT GESETZT') ?></td>
+        </tr>
+        <tr>
+            <td>Employee Type</td>
+            <td>HTTP_EMPLOYEETYPE</td>
+            <td><?= htmlspecialchars($_SERVER['HTTP_EMPLOYEETYPE'] ?? 'NICHT GESETZT') ?></td>
+        </tr>
+    </table>
+    
+    <h2>Alle Shibboleth-Attribute:</h2>
+    <table border="1">
+        <?php
+        foreach ($_SERVER as $key => $value) {
+            if (strpos($key, 'HTTP_') === 0 || in_array($key, ['REMOTE_USER', 'AUTH_TYPE'])) {
+                echo "<tr><td>$key</td><td>" . htmlspecialchars($value) . "</td></tr>";
+            }
+        }
+        ?>
+    </table>
+    
+    <p><a href="/Shibboleth.sso/Logout">Logout</a></p>
+</body>
+</html>

--- a/shibboleth-sp-testapp/shibboleth-sp/attribute-map.xml
+++ b/shibboleth-sp-testapp/shibboleth-sp/attribute-map.xml
@@ -155,4 +155,14 @@
     <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" id="givenName" />
     <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" id="sn" />
 
+    <!-- Anwendungsspezifische Attribut-Mappings -->
+    <Attribute name="urn:mace:dir:attribute-def:displayName" id="displayname"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.241" id="displayname"/>
+
+    <Attribute name="urn:mace:dir:attribute-def:mail" id="email"/>
+    <Attribute name="urn:oid:0.9.2342.19200300.100.1.3" id="email"/>
+
+    <Attribute name="urn:mace:dir:attribute-def:employeeType" id="employeetype"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.4" id="employeetype"/>
+
 </Attributes>

--- a/shibboleth-sp-testapp/shibboleth-sp/shibboleth2.xml
+++ b/shibboleth-sp-testapp/shibboleth-sp/shibboleth2.xml
@@ -20,8 +20,8 @@
     -->
 
     <!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
-    <ApplicationDefaults entityID="https://sp.example.org:2443/Shibboleth.sso/Metadata"
-                         REMOTE_USER="eppn persistent-id targeted-id">
+    <ApplicationDefaults entityID="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/Metadata"
+                     REMOTE_USER="eppn persistent-id targeted-id">
 
         <!--
         Controls session lifetimes, address checks, cookie handling, and the protocol handlers.
@@ -41,7 +41,7 @@
             (Set discoveryProtocol to "WAYF" for legacy Shibboleth WAYF support.)
             You can also override entityID on /Login query string, or in RequestMap/htaccess.
             -->
-            <SSO entityID="https://idp.example.com/idp/shibboleth">
+            <SSO entityID="https://shib-demo.westeurope.cloudapp.azure.com/idp/shibboleth">
               SAML2 SAML1
             </SSO>
 


### PR DESCRIPTION
## Summary
- set IdP entityId and scope for new domain
- configure SP to match new metadata URLs
- expose new relying party configuration
- expand LDAP attribute resolver and sample user data
- map new attributes in SP and expose them via a protected endpoint
- regenerate sample SP metadata

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_6880ee93f0708330a1b55bfeddef8920