### PR TITLE
Refine HAWKI attribute release

### DIFF
--- a/shibboleth-idp-dockerized/ext-conf/conf/attribute-filter.xml
+++ b/shibboleth-idp-dockerized/ext-conf/conf/attribute-filter.xml
@@ -42,4 +42,18 @@
 
     </AttributeFilterPolicy>
 
+    <AttributeFilterPolicy id="HAWKIPolicy">
+        <PolicyRequirementRule xsi:type="Requester"
+            value="https://shib-demo.westeurope.cloudapp.azure.com:2443/Shibboleth.sso/Metadata" />
+        <AttributeRule attributeID="displayname">
+            <PermitValueRule xsi:type="ANY" />
+        </AttributeRule>
+        <AttributeRule attributeID="email">
+            <PermitValueRule xsi:type="ANY" />
+        </AttributeRule>
+        <AttributeRule attributeID="employeetype">
+            <PermitValueRule xsi:type="ANY" />
+        </AttributeRule>
+    </AttributeFilterPolicy>
+
 </AttributeFilterPolicyGroup>

--- a/shibboleth-idp-dockerized/ext-conf/conf/attribute-resolver-full.xml
+++ b/shibboleth-idp-dockerized/ext-conf/conf/attribute-resolver-full.xml
@@ -256,12 +256,6 @@
     despite the problems with that practice. Consider making the EPPN
     value the same as your official email addresses whenever possible.
     -->
-    <resolver:AttributeDefinition id="mail" xsi:type="ad:Simple" sourceAttributeID="mail">
-        <resolver:Dependency ref="myLDAP" />
-        <resolver:AttributeEncoder xsi:type="enc:SAML1String" name="urn:mace:dir:attribute-def:mail" />
-        <resolver:AttributeEncoder xsi:type="enc:SAML2String" name="urn:oid:0.9.2342.19200300.100.1.3" friendlyName="mail" />
-    </resolver:AttributeDefinition>
-
     <resolver:AttributeDefinition id="sn" xsi:type="ad:Simple" sourceAttributeID="sn">
         <resolver:Dependency ref="myLDAP" />
         <resolver:AttributeEncoder xsi:type="enc:SAML1String" name="urn:mace:dir:attribute-def:sn" />
@@ -348,22 +342,22 @@
     </resolver:DataConnector>
 
     <!-- Zusätzliche Attribute für Anwendungsintegration -->
-    <resolver:AttributeDefinition id="displayname" xsi:type="ad:Simple">
-        <resolver:InputDataConnector ref="myLDAP" attributeNames="cn displayName"/>
+    <resolver:AttributeDefinition id="displayname" xsi:type="ad:Simple" sourceAttributeID="displayName">
+        <resolver:Dependency ref="myLDAP" />
         <resolver:AttributeEncoder xsi:type="enc:SAML2String"
                       name="urn:mace:dir:attribute-def:displayName"
                       friendlyName="displayname"/>
     </resolver:AttributeDefinition>
 
-    <resolver:AttributeDefinition id="email" xsi:type="ad:Simple">
-        <resolver:InputDataConnector ref="myLDAP" attributeNames="mail"/>
+    <resolver:AttributeDefinition id="email" xsi:type="ad:Simple" sourceAttributeID="mail">
+        <resolver:Dependency ref="myLDAP" />
         <resolver:AttributeEncoder xsi:type="enc:SAML2String"
                       name="urn:mace:dir:attribute-def:mail"
                       friendlyName="email"/>
     </resolver:AttributeDefinition>
 
-    <resolver:AttributeDefinition id="employeetype" xsi:type="ad:Simple">
-        <resolver:InputDataConnector ref="myLDAP" attributeNames="employeeType"/>
+    <resolver:AttributeDefinition id="employeetype" xsi:type="ad:Simple" sourceAttributeID="employeeType">
+        <resolver:Dependency ref="myLDAP" />
         <resolver:AttributeEncoder xsi:type="enc:SAML2String"
                       name="urn:mace:dir:attribute-def:employeeType"
                       friendlyName="employeetype"/>


### PR DESCRIPTION
## Summary
- fix attribute resolver definitions for HAWKI attributes
- clean up duplicate mail definition
- add dedicated attribute-filter policy for HAWKI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f871f0c48330b7ed9b68994f7459